### PR TITLE
fixing border bug

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -28,7 +28,7 @@ Author: Eiji Kitamura (agektmr@gmail.com)
 }
 .box div {
   background-color: #eee;
-  border: outset 1px #aaa;
+  box-shadow: inset 0 0 0 1px #aaa;
   -webkit-transition: all 0.1s ease-out 0s;
   white-space: no-wrap;
   text-overflow: ellipsis;

--- a/css/style.less
+++ b/css/style.less
@@ -27,7 +27,7 @@ Author: Eiji Kitamura (agektmr@gmail.com)
   -webkit-transition: all 0.1s ease-out 0.0s;
   div {
     background-color: #eee;
-    border: outset 1px #aaa;
+    box-shadow: inset 0 0 0 1px #aaa;
     -webkit-transition: all 0.1s ease-out 0.0s;
     white-space: no-wrap;
     text-overflow: ellipsis;


### PR DESCRIPTION
Hey guys,

There's a bug that has existed on the site for as long as I can remember. Due to the `border` property on the div, having two div's that are `flex: 1 1 50%;` do not line up on the same row.

Screenshot of the issue.
![screenshot 2018-01-30 09 25 23](https://user-images.githubusercontent.com/3136271/35572219-27423d36-05a2-11e8-8c2f-aa35bfa8c4af.png)


To fix this, I changed the border to a box-shadow inset, so that it adds nothing to the box-model os each object.

Before this, the site would require `flex: 1 1 49%;` to work. Screenshot of that.
![screenshot 2018-01-30 09 23 54](https://user-images.githubusercontent.com/3136271/35572249-3c12f82c-05a2-11e8-896b-31c71a20e1ac.png)
